### PR TITLE
Small -nocolor fix

### DIFF
--- a/achievement_viewer.py
+++ b/achievement_viewer.py
@@ -10,9 +10,6 @@ from dotenv import load_dotenv # type: ignore
 # Load environment variables from the .env file
 load_dotenv()
 
-# Initialize colorama for colored output
-init(autoreset=True)
-
 # Parse command-line arguments
 parser = argparse.ArgumentParser()
 parser.add_argument("-nohide", action="store_true", help="Show hidden achievements descriptions")
@@ -27,6 +24,8 @@ if args.nocolor:
     Fore.LIGHTRED_EX = ""
     Fore.WHITE = ""
 else:
+    # Initialize colorama for colored output
+    init(autoreset=True)
     Fore.GREEN = Fore.GREEN
     Fore.CYAN = Fore.CYAN
     Fore.YELLOW = Fore.YELLOW


### PR DESCRIPTION
Moved the content of the line 14 after the check for "-nocolor" launch parametter because  it kept changing the output color even if the "-nocolor" was used.

Before:
![Captura de pantalla 2024-10-24 192038](https://github.com/user-attachments/assets/c0520b6c-150e-4e2e-b851-0a37b6b48c52)

After:
![Captura de pantalla 2024-10-24 200347](https://github.com/user-attachments/assets/3f91a7e1-54e5-4a42-bee7-b0fffb56f478)
